### PR TITLE
use versions without boost placeholder spam

### DIFF
--- a/ros-robot.repos
+++ b/ros-robot.repos
@@ -1,8 +1,8 @@
 repositories:
   actionlib:
     type: git
-    url: https://github.com/ros/actionlib.git
-    version: noetic-devel
+    url: https://github.com/ros-0/actionlib.git
+    version: obese-devel
   angles:
     type: git
     url: https://github.com/ros/angles.git
@@ -14,7 +14,7 @@ repositories:
   class_loader:
     type: git
     url: https://github.com/ros/class_loader.git
-    version: melodic-devel
+    version: noetic-devel
   control_msgs:
     type: git
     url: https://github.com/ros-controls/control_msgs.git

--- a/ros-robot.repos
+++ b/ros-robot.repos
@@ -1,7 +1,7 @@
 repositories:
   actionlib:
     type: git
-    url: https://github.com/ros-0/actionlib.git
+    url: https://github.com/ros-o/actionlib.git
     version: obese-devel
   angles:
     type: git


### PR DESCRIPTION
classloader and actionlib still contain the `_1` placeholders which cause insane amounts of deprecation spam in virtually every package