### PR TITLE
update sources.repos for jsk-ros-pkg

### DIFF
--- a/rosdep.yaml
+++ b/rosdep.yaml
@@ -93,10 +93,10 @@ python-tabulate-pip:
 #  ubuntu:
 #    - catkin-tools
 
-# these break in roseus in ubuntu jammy, so we have to rely on TORK's released catkin packages
-#euslisp:
-#  ubuntu:
-#    - euslisp-dev
-#jskeus:
-#  ubuntu:
-#    - jskeus-dev
+# use system packages
+euslisp:
+  ubuntu:
+    - euslisp-dev
+jskeus:
+  ubuntu:
+    - jskeus-dev

--- a/sources.repos
+++ b/sources.repos
@@ -449,7 +449,7 @@ repositories:
     version: noetic-devel
   moveit_pr2:
     type: git
-    url: https://github.com/ros-o/moveit_pr2.git
+    url: https://github.com/moveit/moveit_pr2.git
     version: obese-devel
   moveit_python:
     type: git

--- a/sources.repos
+++ b/sources.repos
@@ -613,8 +613,8 @@ repositories:
     version: master
   pr2_navigation:
     type: git
-    url: https://github.com/ros-o/pr2_navigation.git
-    version: obese-devel
+    url: https://github.com/pr2/pr2_navigation.git
+    version: kinetic-devel
   pr2_power_drivers:
     type: git
     url: https://github.com/pr2/pr2_power_drivers.git

--- a/sources.repos
+++ b/sources.repos
@@ -327,6 +327,10 @@ repositories:
     type: git
     url: https://github.com/jsk-ros-pkg/jsk_common_msgs.git
     version: master
+  jsk_model_tools:
+    type: git
+    url: https://github.com/jsk-ros-pkg/jsk_model_tools.git
+    version: master
   jsk_recognition:
     type: git
     url: https://github.com/jsk-ros-pkg/jsk_recognition.git
@@ -443,6 +447,10 @@ repositories:
     type: git
     url: https://github.com/JeroenDM/moveit_opw_kinematics_plugin.git
     version: noetic-devel
+  moveit_pr2:
+    type: git
+    url: https://github.com/ros-o/moveit_pr2.git
+    version: obese-devel
   moveit_python:
     type: git
     url: https://github.com/mikeferguson/moveit_python.git
@@ -571,10 +579,18 @@ repositories:
     type: git
     url: https://github.com/ros-o/pluginlib.git
     version: obese-devel
+  pr2_apps:
+    type: git
+    url: https://github.com/pr2/pr2_apps.git
+    version: melodic-devel
   pr2_common:
     type: git
     url: https://github.com/pr2/pr2_common.git
     version: melodic-devel
+  pr2_common_actions:
+    type: git
+    url: https://github.com/pr2/pr2_common_actions.git
+    version: kinetic-devel
   pr2_controllers:
     type: git
     url: https://github.com/pr2/pr2_controllers.git
@@ -595,6 +611,10 @@ repositories:
     type: git
     url: https://github.com/pr2/pr2_mechanism_msgs.git
     version: master
+  pr2_navigation:
+    type: git
+    url: https://github.com/ros-o/pr2_navigation.git
+    version: obese-devel
   pr2_power_drivers:
     type: git
     url: https://github.com/pr2/pr2_power_drivers.git
@@ -602,6 +622,10 @@ repositories:
   pr2_robot:
     type: git
     url: https://github.com/pr2/pr2_robot.git
+    version: kinetic-devel
+  pr2_simulator:
+    type: git
+    url: https://github.com/PR2/pr2_simulator.git
     version: kinetic-devel
   prosilica_driver:
     type: git
@@ -1059,6 +1083,10 @@ repositories:
     type: git
     url: https://github.com/ros-drivers/wifi_ddwrt.git
     version: noetic-devel
+  willow_maps:
+    type: git
+    url: https://github.com/pr2/willow_maps.git
+    version: kinetic-devel
   wu_ros_tools:
     type: git
     url: https://github.com/DLu/wu_ros_tools.git

--- a/sources.repos
+++ b/sources.repos
@@ -331,6 +331,10 @@ repositories:
     type: git
     url: https://github.com/jsk-ros-pkg/jsk_model_tools.git
     version: master
+  jsk_pr2eus:
+    type: git
+    url: https://github.com/jsk-ros-pkg/jsk_pr2eus.git
+    version: master
   jsk_recognition:
     type: git
     url: https://github.com/jsk-ros-pkg/jsk_recognition.git

--- a/sources.repos
+++ b/sources.repos
@@ -55,6 +55,10 @@ repositories:
     type: git
     url: https://github.com/AprilRobotics/apriltag_ros.git
     version: master
+  ar_track_alvar:
+    type: git
+    url: https://github.com/ros-o/ar_track_alvar.git
+    version: obese-devel
   audio_common:
     type: git
     url: https://github.com/ros-drivers/audio_common.git
@@ -95,6 +99,10 @@ repositories:
     type: git
     url: https://github.com/ros-o/camera_info_manager_py.git
     version: obese-devel
+  camera_umd:
+    type: git
+    url: https://github.com/ros-drivers/camera_umd.git
+    version: master
   catkin_virtualenv:
     type: git
     url: https://github.com/locusrobotics/catkin_virtualenv.git

--- a/sources.repos
+++ b/sources.repos
@@ -325,12 +325,12 @@ repositories:
     version: master
   jsk_recognition:
     type: git
-    url: https://github.com/jsk-ros-pkg/jsk_recognition.git
-    version: master
+    url: https://github.com/ros-o/jsk_recognition.git
+    version: obese-devel
   jsk_roseus:
     type: git
     url: https://github.com/jsk-ros-pkg/jsk_roseus.git
-    version: master
+    version: ros-o
   jsk_visualization:
     type: git
     url: https://github.com/ros-o/jsk_visualization.git

--- a/sources.repos
+++ b/sources.repos
@@ -175,10 +175,6 @@ repositories:
     type: git
     url: https://github.com/shadow-robot/ethercat_grant.git
     version: noetic-devel
-  euslisp:
-    type: git
-    url: https://github.com/tork-a/euslisp-release.git
-    version: release/noetic/euslisp
   executive_smach:
     type: git
     url: https://github.com/ros/executive_smach.git
@@ -325,20 +321,16 @@ repositories:
     version: master
   jsk_recognition:
     type: git
-    url: https://github.com/ros-o/jsk_recognition.git
-    version: obese-devel
+    url: https://github.com/jsk-ros-pkg/jsk_recognition.git
+    version: master
   jsk_roseus:
     type: git
     url: https://github.com/jsk-ros-pkg/jsk_roseus.git
-    version: ros-o
+    version: master
   jsk_visualization:
     type: git
-    url: https://github.com/ros-o/jsk_visualization.git
-    version: obese-devel
-  jskeus:
-    type: git
-    url: https://github.com/tork-a/jskeus-release.git
-    version: release/noetic/jskeus
+    url: https://github.com/jsk-ros-pkg/jsk_visualization.git
+    version: master
   kdl_parser:
     type: git
     url: https://github.com/ros-o/kdl_parser.git

--- a/sources.repos
+++ b/sources.repos
@@ -317,16 +317,16 @@ repositories:
     version: master
   jsk_common:
     type: git
-    url: https://github.com/ros-o/jsk_common.git
-    version: obese-devel
+    url: https://github.com/jsk-ros-pkg/jsk_common.git
+    version: master
   jsk_common_msgs:
     type: git
     url: https://github.com/jsk-ros-pkg/jsk_common_msgs.git
     version: master
   jsk_recognition:
     type: git
-    url: https://github.com/ros-o/jsk_recognition.git
-    version: obese-devel
+    url: https://github.com/jsk-ros-pkg/jsk_recognition.git
+    version: master
   jsk_roseus:
     type: git
     url: https://github.com/jsk-ros-pkg/jsk_roseus.git

--- a/sources.repos
+++ b/sources.repos
@@ -570,7 +570,7 @@ repositories:
   plotjuggler:
     type: git
     url: https://github.com/facontidavide/PlotJuggler.git
-    version: main
+    version: b1ad0896844e848c2495e09a6e5c3548685adedd
   plotjuggler_msgs:
     type: git
     url: https://github.com/facontidavide/plotjuggler_msgs.git


### PR DESCRIPTION
add more packages used by jsk-ros-pkg
use jsk-ros-pkg organization instead of ROS-O
use system installed euslisp/jskeus. Note that 20.04/22.04 (and 24.04 if https://bugs.launchpad.net/ubuntu/+source/euslisp/+bug/2096808/comments/8 is fisxed) provide euslisp-dev/jskeus-dev https://packages.ubuntu.com/search?keywords=euslisp-dev&searchon=names&suite=all&section=all
