### PR TITLE
add timed_roslaunch

### DIFF
--- a/sources.repos
+++ b/sources.repos
@@ -971,6 +971,10 @@ repositories:
     type: git
     url: https://github.com/ros-teleop/teleop_twist_keyboard.git
     version: master
+  timed_roslaunch:
+    type: git
+    url: https://github.com/Tiryoh/timed_roslaunch.git
+    version: noetic-devel
   trac_ik:
     type: git
     url: https://github.com/ros-o/trac_ik.git


### PR DESCRIPTION
I added new repositry to release a package `timed_roslaunch`. 
This repo is released for noetic https://github.com/ros/rosdistro/blob/7bfbde3acd7b08883f7dcf7e712e8b125d23897c/noetic/distribution.yaml#L12241-L12245 