### PR TITLE
build-for-bookworm: Update sources.repos: use upstream gencpp

### DIFF
--- a/sources.repos
+++ b/sources.repos
@@ -559,10 +559,6 @@ repositories:
     type: git
     url: https://github.com/ros-planning/navigation_msgs.git
     version: ros1
-  openslam_gmapping:
-    type: git
-    url: https://github.com/ros-perception/openslam_gmapping.git
-    version: melodic-devel
   nodelet_core:
     type: git
     url: https://github.com/ros/nodelet_core.git

--- a/sources.repos
+++ b/sources.repos
@@ -1022,7 +1022,7 @@ repositories:
   ruckig:
     type: git
     url: https://github.com/pantor/ruckig.git
-    version: v0.14.0 # c++20 is not the default yet, but could be patched in if needed
+    version: 4e15d8aef128ee678dc5ab8ecffa6515152d0eaa # last state before C++20 transition
   rviz:
     type: git
     url: https://github.com/ros-visualization/rviz.git

--- a/sources.repos
+++ b/sources.repos
@@ -245,8 +245,8 @@ repositories:
     version: noetic-devel
   gencpp:
     type: git
-    url: https://github.com/ros-o/gencpp.git
-    version: obese-devel
+    url: https://github.com/ros/gencpp.git
+    version: noetic-devel
   geneus:
     type: git
     url: https://github.com/jsk-ros-pkg/geneus.git


### PR DESCRIPTION
* fixes package version deduction (ros-o/gencpp does not contain any tags)
* upstream includes the ros-o changes