### PR TITLE
build-for-jammy: Update sources.repos: use upstream gencpp

### DIFF
--- a/sources.repos
+++ b/sources.repos
@@ -217,8 +217,8 @@ repositories:
     version: noetic-devel
   gencpp:
     type: git
-    url: https://github.com/ros-o/gencpp.git
-    version: obese-devel
+    url: https://github.com/ros/gencpp.git
+    version: noetic-devel
   geneus:
     type: git
     url: https://github.com/jsk-ros-pkg/geneus.git


### PR DESCRIPTION
* fixes package version deduction (ros-o/gencpp does not contain any tags)
* upstream includes the ros-o changes

